### PR TITLE
chore: GitHub Actions の依存を更新

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -14,6 +14,6 @@ jobs:
       pull-requests: write
     timeout-minutes: 30
     steps:
-      - uses: TimonVS/pr-labeler-action@f9c084306ce8b3f488a8f3ee1ccedc6da131d1af
+      - uses: TimonVS/pr-labeler-action@f9c084306ce8b3f488a8f3ee1ccedc6da131d1af # v5.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       contents: write
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: ./
         id: next-latest-release
@@ -42,8 +42,8 @@ jobs:
           git config --local user.name $GIT_USER_NAME
           git config --local user.email $GIT_USER_EMAIL
 
-          git tag -f "${{ steps.next-latest-release.outputs.version }}"
-          git push -f origin "${{ steps.next-latest-release.outputs.version }}"
+          git tag "${{ steps.next-latest-release.outputs.version }}"
+          git push origin "${{ steps.next-latest-release.outputs.version }}"
 
           git tag -f "${{ steps.next-latest-release.outputs.version-major }}"
           git push -f origin "${{ steps.next-latest-release.outputs.version-major }}"

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: actions/github-script@v7
+    - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       id: next-latest-release
       env:
         BUMP: ${{ inputs.bump }}

--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-const fs = require('fs');
-
 module.exports = async function ({
   core,
   github,


### PR DESCRIPTION
## 変更内容

- actions/github-script を v9.0.0 に更新し、SHA pin に変更
- actions/checkout を v6.0.2 に更新し、SHA pin に変更
- pr-labeler-action の既存 SHA pin にバージョンコメントを追加
- 未使用の fs import を削除
- 固定バージョンタグは force 更新せず、major タグのみ既存どおり force 更新するように変更

## 確認

- ruby -e 'require "yaml"; ...' による YAML 読み込み確認
- node -e による index.js の patch bump 出力確認